### PR TITLE
Enable fast-forward on iOS

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -652,8 +652,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     result([FlutterError errorWithCode:@"unsupported_speed"
                                message:@"Speed must be >= 0.0 and <= 2.0"
                                details:nil]);
-  } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
-             (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {
+// Fix from: https://github.com/jhomlala/betterplayer/issues/574#issuecomment-879657453
+  } else if ((speed > 1.0) || (speed < 1.0))) {
     _playerRate = speed;
     result(nil);
   } else {


### PR DESCRIPTION
On iOS setting speed higher than 1.0 throws `PlatformException(unsupported_fast_forward, This video cannot be played fast forward, null, null)`. 
I took the solution from there https://github.com/jhomlala/betterplayer/issues/574#issuecomment-879657453